### PR TITLE
Replace structopt & failure crates

### DIFF
--- a/src/msnmp/Cargo.toml
+++ b/src/msnmp/Cargo.toml
@@ -11,9 +11,8 @@ keywords = ["snmp", "snmpv3" ]
 categories = ["command-line-utilities"]
 
 [dependencies]
-exitfailure = "0.5.1"
-failure = "0.1.8"
 rand = "0.7.3"
 snmp_mp = "0.1.0"
 snmp_usm = "0.2.1"
 clap = { version = "4.5.60", features = ["derive", "help", "std", "usage"], default-features = false }
+anyhow = "1.0.102"

--- a/src/msnmp/Cargo.toml
+++ b/src/msnmp/Cargo.toml
@@ -16,4 +16,4 @@ failure = "0.1.8"
 rand = "0.7.3"
 snmp_mp = "0.1.0"
 snmp_usm = "0.2.1"
-structopt = "0.3.17"
+clap = { version = "4.5.60", features = ["derive", "help", "std", "usage"], default-features = false }

--- a/src/msnmp/src/lib.rs
+++ b/src/msnmp/src/lib.rs
@@ -5,17 +5,14 @@ mod params;
 mod request;
 mod session;
 
+use anyhow::Result;
 use client::Client;
-use failure::Error;
 pub use params::{Command, Params};
 use session::{Session, Step};
 use snmp_mp::PduType;
 use snmp_usm::{
     Aes128PrivKey, AuthKey, DesPrivKey, Digest, LocalizedKey, Md5, PrivKey, Sha1, WithLocalizedKey,
 };
-
-#[macro_use]
-extern crate failure;
 
 const SNMP_PORT_NUM: u32 = 161;
 
@@ -37,7 +34,7 @@ macro_rules! execute_request {
     }};
 }
 
-pub fn run(params: Params) -> Result<(), Error> {
+pub fn run(params: Params) -> Result<()> {
     if Some(Params::SHA1_DIGEST) == params.auth_protocol.as_deref() {
         execute_request!(Sha1, params)
     } else {
@@ -45,7 +42,7 @@ pub fn run(params: Params) -> Result<(), Error> {
     }
 }
 
-fn execute_request<'a, D, P, S>(params: Params, salt: P::Salt) -> Result<(), Error>
+fn execute_request<'a, D, P, S>(params: Params, salt: P::Salt) -> Result<()>
 where
     D: Digest + 'a,
     P: PrivKey<Salt = S> + WithLocalizedKey<'a, D>,

--- a/src/msnmp/src/main.rs
+++ b/src/msnmp/src/main.rs
@@ -1,9 +1,9 @@
 //! Main doc.
+use anyhow::Result;
 use clap::Parser as _;
-use exitfailure::ExitFailure;
 use msnmp::{self, Params};
 
-fn main() -> Result<(), ExitFailure> {
+fn main() -> Result<()> {
     let args = Params::try_parse()?;
     msnmp::run(args)?;
 

--- a/src/msnmp/src/main.rs
+++ b/src/msnmp/src/main.rs
@@ -1,10 +1,10 @@
 //! Main doc.
+use clap::Parser as _;
 use exitfailure::ExitFailure;
 use msnmp::{self, Params};
-use structopt::StructOpt;
 
 fn main() -> Result<(), ExitFailure> {
-    let args = Params::from_args();
+    let args = Params::try_parse()?;
     msnmp::run(args)?;
 
     Ok(())

--- a/src/msnmp/src/params.rs
+++ b/src/msnmp/src/params.rs
@@ -1,20 +1,21 @@
-use structopt::StructOpt;
+use clap::Parser;
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
+#[clap()]
 pub struct Params {
-    #[structopt(short, long, required = true)]
+    #[clap(short, long, required = true)]
     pub user: String,
-    #[structopt(short, long, required = true)]
+    #[clap(short, long, required = true)]
     pub host: String,
-    #[structopt(short, long)]
+    #[clap(short, long)]
     pub auth: Option<String>,
-    #[structopt(short = "A", long, possible_values = &[Self::MD5_DIGEST, Self::SHA1_DIGEST])]
+    #[clap(short = 'A', long, value_parser = clap::builder::PossibleValuesParser::new([Self::MD5_DIGEST, Self::SHA1_DIGEST]))]
     pub auth_protocol: Option<String>,
-    #[structopt(short, long)]
+    #[clap(short, long)]
     pub privacy: Option<String>,
-    #[structopt(short = "P", long, possible_values = &[Self::DES_ENCRYPTION, Self::AES128_ENCRYPTION])]
+    #[clap(short = 'P', long, value_parser = clap::builder::PossibleValuesParser::new([Self::DES_ENCRYPTION, Self::AES128_ENCRYPTION]))]
     pub privacy_protocol: Option<String>,
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     pub cmd: Command,
 }
 
@@ -25,29 +26,29 @@ impl Params {
     pub const AES128_ENCRYPTION: &'static str = "AES128";
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 pub enum Command {
-    #[structopt(about = "Performs an SNMP GET operation")]
+    #[clap(about = "Performs an SNMP GET operation")]
     Get {
-        #[structopt(
+        #[clap(
             name = "OID",
             help = "One or more object identifiers separated by spaces",
             required = true
         )]
         oids: Vec<String>,
     },
-    #[structopt(about = "Performs an SNMP GET NEXT operation")]
+    #[clap(about = "Performs an SNMP GET NEXT operation")]
     GetNext {
-        #[structopt(
+        #[clap(
             name = "OID",
             help = "One or more object identifiers separated by spaces",
             required = true
         )]
         oids: Vec<String>,
     },
-    #[structopt(about = "Retrieves a subtree of management values")]
+    #[clap(about = "Retrieves a subtree of management values")]
     Walk {
-        #[structopt(name = "OID", help = "Optional object identifier")]
+        #[clap(name = "OID", help = "Optional object identifier")]
         oid: Option<String>,
     },
 }

--- a/src/msnmp/src/request.rs
+++ b/src/msnmp/src/request.rs
@@ -1,5 +1,5 @@
 use crate::{format_var_bind, msg_factory, Client, Session, Step};
-use failure::Error;
+use anyhow::{anyhow, Result};
 use snmp_mp::{ObjectIdent, PduType, SnmpMsg, VarBind, VarValue};
 use snmp_usm::{Digest, PrivKey};
 use std::str::FromStr;
@@ -11,7 +11,7 @@ pub fn snmp_get<D, P, S>(
     oids: Vec<String>,
     client: &mut Client,
     session: &mut Session<D, P, S>,
-) -> Result<(), Error>
+) -> Result<()>
 where
     D: Digest,
     P: PrivKey<Salt = S>,
@@ -19,7 +19,7 @@ where
 {
     let var_binds = strings_to_var_binds(oids.iter());
     if var_binds.is_empty() {
-        return Err(format_err!("invalid OID(s) supplied"));
+        return Err(anyhow!("invalid OID(s) supplied"));
     }
 
     let mut get_request = msg_factory::create_request_msg(pdu_type, var_binds, session);
@@ -38,7 +38,7 @@ pub fn snmp_walk<D, P, S>(
     oid: Option<String>,
     client: &mut Client,
     session: &mut Session<D, P, S>,
-) -> Result<(), Error>
+) -> Result<()>
 where
     D: Digest,
     P: PrivKey<Salt = S>,


### PR DESCRIPTION
The structopt and failure crates are obsolete and no longer maintained. This PR replaces them with clap & anyhow.

I haven't done any testing of these changes, since I do not run the msnmp utility.